### PR TITLE
Added a useful link to explain the use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@ mapreduce-tutorial
 ==================
 To generate the jar:
 mvn install
+
+The use case and a detailed description of this tutorial is available
+[here](http://blog.cloudera.com/blog/2012/12/how-to-run-a-mapreduce-job-in-cdh4/ "How-To: Run a MapReduce Job in CDH4").


### PR DESCRIPTION
When a person lands in this github repo first, he would not have any context info regarding the use case.  It would be useful to provide a link to the actual blog post where a detailed description of the use case of this code sample is present.
